### PR TITLE
Fix url for libsodium

### DIFF
--- a/pkg/osx/build_env.sh
+++ b/pkg/osx/build_env.sh
@@ -140,7 +140,7 @@ sudo -H $MAKE install
 ############################################################################
 echo -n -e "\033]0;Build_Env: libsodium\007"
 
-PKGURL="https://download.libsodium.org/libsodium/releases/libsodium-1.0.12.tar.gz"
+PKGURL="https://download.libsodium.org/libsodium/releases/old/libsodium-1.0.12.tar.gz"
 PKGDIR="libsodium-1.0.12"
 
 download $PKGURL


### PR DESCRIPTION
### What does this PR do?
Fixes the url for libsodium. Libsodium moved the version used in this version of salt to a subdirectory called `old`

### What issues does this PR fix or reference?
Building on OSX

### Tests written?
NA

### Commits signed with GPG?
Yes