### PR TITLE
Fix win_pkg test

### DIFF
--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -131,7 +131,10 @@ def check_file_list_cache(opts, form, list_cache, w_lock):
                 if os.path.exists(list_cache):
                     # calculate filelist age is possible
                     cache_stat = os.stat(list_cache)
-                    age = time.time() - cache_stat.st_mtime
+                    # st_time can have a greater precision than time, removing
+                    # float precision makes sure age will never be a negative
+                    # number.
+                    age = int(time.time()) - int(cache_stat.st_mtime)
                 else:
                     # if filelist does not exists yet, mark it as expired
                     age = opts.get('fileserver_list_cache_time', 20) + 1

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -693,14 +693,12 @@ def refresh_db(**kwargs):
 
     # Cache repo-ng locally
     log.info('Fetching *.sls files from {0}'.format(repo_details.winrepo_source_dir))
-    ret = __salt__['cp.cache_dir'](
+    __salt__['cp.cache_dir'](
         path=repo_details.winrepo_source_dir,
         saltenv=saltenv,
         include_pat='*.sls',
         exclude_pat=r'E@\/\..*?\/'  # Exclude all hidden directories (.git)
     )
-    log.debug("refresh_db - Return from cache_dir %s", repr(ret))
-
     return genrepo(saltenv=saltenv, verbose=verbose, failhard=failhard)
 
 

--- a/tests/integration/modules/test_win_pkg.py
+++ b/tests/integration/modules/test_win_pkg.py
@@ -75,8 +75,6 @@ class WinPKGTest(ModuleCase):
                     locale: en_US
                     reboot: False
                 '''))
-            fp_.flush()
-            os.fsync(fp_.fileno())
         # now check if curl is also in cache and repo query
         pkgs.append('curl')
         for pkg in pkgs:


### PR DESCRIPTION
Bugfix in file_list cache. The file_list cache age could be a negative
number meaning the file_list cache can get used in tests even though the
cache timeout is set to 0 for test suite runs.
